### PR TITLE
Add decrement event tracking

### DIFF
--- a/src/analytics/events.ts
+++ b/src/analytics/events.ts
@@ -2,3 +2,6 @@ import { trackEvent } from "./trackEvent";
 
 export const trackIncrement = (value: Number) =>
   trackEvent("Counter", "Counter incremented", { value });
+
+export const trackDecrement = (value: Number) =>
+trackEvent("Counter", "Counter decremented", { value });

--- a/src/features/counter/counterSlice.ts
+++ b/src/features/counter/counterSlice.ts
@@ -1,7 +1,7 @@
 import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { RootState, AppThunk } from '../../app/store';
 import { fetchCount } from './counterAPI';
-import { trackIncrement } from '../../analytics/events';
+import { trackIncrement, trackDecrement } from '../../analytics/events';
 
 export interface CounterState {
   value: number;
@@ -41,6 +41,7 @@ export const counterSlice = createSlice({
       state.value += 1;
     },
     decrement: (state) => {
+      trackDecrement(state.value - 1)
       state.value -= 1;
     },
     // Use the PayloadAction type to declare the contents of `action.payload`


### PR DESCRIPTION
This PR adds tracking for the decrement counter, as Part 1 of the Synthesia Analytics Engineering challenge.

It mimics the tracking of the increment counter as instrumented with [Segment](https://segment.com/docs/)